### PR TITLE
Fix timeout issue for py312

### DIFF
--- a/portal/__init__.py
+++ b/portal/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.5.0'
+__version__ = '3.5.1'
 
 import multiprocessing as mp
 try:

--- a/portal/client_socket.py
+++ b/portal/client_socket.py
@@ -238,9 +238,7 @@ class ClientSocket:
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, every)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, fails)
-        sock.setsockopt(
-            socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT,
-            1000 * (after + every * fails))
+        sock.settimeout((after + every * fails) / 1000)
       if sys.platform == 'darwin':
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, every)


### PR DESCRIPTION
Python3.12 does not support `socket.TCP_USER_TIMEOUT`, refer to [link](https://www.pythonlore.com/working-with-socket-timeouts-in-python/)